### PR TITLE
Add eslintrc support

### DIFF
--- a/lib/plato.js
+++ b/lib/plato.js
@@ -75,7 +75,7 @@ function inspect(files, outputDir, options, done) {
 
 	function cloneOptsAtFlag(flag) {
 		if (flag in options) {
-      if (typeof options[flag] === 'boolean') {
+      if (typeof options[flag] === 'boolean' && flag === 'eslint') {
         flags[flag] = options[flag];
       } else {
         flags[flag] = _.extend({}, flags[flag], options[flag]);   

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -75,7 +75,11 @@ function inspect(files, outputDir, options, done) {
 
 	function cloneOptsAtFlag(flag) {
 		if (flag in options) {
-			flags[flag] = _.extend({},flags[flag], options[flag]);
+      if (typeof options[flag] === 'boolean') {
+        flags[flag] = options[flag];
+      } else {
+        flags[flag] = _.extend({}, flags[flag], options[flag]);   
+      }
 		}
 	}
 	

--- a/lib/reporters/eslint/index.js
+++ b/lib/reporters/eslint/index.js
@@ -37,8 +37,9 @@ function generateReport(data) {
 }
 
 function lint(source, options, file) {
-	options = options || {};
-
+	if (typeof options === 'boolean') {
+		options = null;
+	}
 	var data = [];
 
   // Remove potential Unicode BOM.


### PR DESCRIPTION
This pull request adds support for the `eslintrc` file.  Since the ESLint `CLIEngine` will use the file when no `options` are passed the constructor, I figured it made sense to support the configuration property as a boolean and object.  This way, you can use it to enable, disable, or pass in an object.

* `eslint: { /* set of rules */ }` merges default rules (current behavior)
* `eslint: false` disables running eslint (**new** behavior)
* `eslint: true` uses `eslintrc` file (**new** behavior)

I tried to run tests but they seem to be out of date.  Let me know if there's a specific way I should be running them.

I also edited these files directly in :octocat:.  This is due to the `.editorconfig` file getting ingested by my IDE.  Happy to clean them up at some point but out of scope for this pull request.