### PR TITLE
Offer eslintrc option in cli and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,16 @@ Usage : es6-plato [options] -d <output_dir> <input files>
       The output directory
   -r, --recurse
       Recursively search directories
+  -l, --jshint : String
+      Specify a jshintrc file for JSHint linting
   -t, --title : String
       Title of the report
   -D, --date : String
       Time to use as the report date (seconds, > 9999999999 assumed to be ms)
+  -n, --noempty
+      Skips empty lines from line count
+  -e, --eslint : String
+      Specify a eslintrc file for ESLint linting
 ```
 
 **Example**

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -33,7 +33,8 @@ function exec(options, done) {
 		q: !!exports.args.q,
 		title: exports.args.t && exports.args.t.value,
 		exclude: exports.args.x && new RegExp(exports.args.x.value),
-		date: exports.args.D && exports.args.D.value
+		date: exports.args.D && exports.args.D.value,
+		eslintrc: exports.args.e && exports.args.e.value
 	};
 
 	if (exports.args.l) {

--- a/lib/cli/options.json
+++ b/lib/cli/options.json
@@ -51,5 +51,10 @@
     "long": "noempty",
     "desc": "Skips empty lines from line count",
     "type": "Boolean"
+  },
+  "e": {
+    "long": "eslint",
+    "desc": "Specify a eslintrc file for ESLint linting",
+    "type": "String"
   }
 }

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -72,7 +72,9 @@ function inspect(files, outputDir, options, done) {
 			newmi: true,
 			range: true
 		},
-		eslint: eslintBase
+		eslint: options.eslintrc
+			? path.resolve(options.eslintrc)
+			: eslintBase
 	};
 
 	function cloneOptsAtFlag(flag) {


### PR DESCRIPTION
Fixes #50 

- The cli option is passed to the plato.js.
- Readme is up-to-date.
