### PR TITLE
Prevent undefined line number for toplevel errors - closes #99

### DIFF
--- a/lib/assets/scripts/plato-file.js
+++ b/lib/assets/scripts/plato-file.js
@@ -160,6 +160,7 @@ $(function() {
 					lines[line] += '<div class="plato-jshint-message text-' + message.severity + '">' + text + '</div>';
 				});
 			} else {
+				if (typeof message.line === 'undefined') message.line = '1'
 				if (!lines[message.line]) lines[message.line] = '';
 				lines[message.line] += '<div class="plato-jshint-message text-' + message.severity + '">' + text + '</div>';
 			}


### PR DESCRIPTION
Currently toplevel errors are not working as these are not bound to a lline as it sees and are on line number 0 but the files start with 1.

This PR provides a fix for this.
But I guess kultiplke toplevel errors / errors on the same line do not work as they are overwritten on each iteration of `forEach`

![image](https://user-images.githubusercontent.com/827205/64564422-ca382680-d351-11e9-860e-fb0ca0ecca79.png)

![image](https://user-images.githubusercontent.com/827205/64564478-e89e2200-d351-11e9-9918-9116426a1b6e.png)
