### PR TITLE
Fix GitHub spelling

### DIFF
--- a/lib/templates/file.html
+++ b/lib/templates/file.html
@@ -25,7 +25,7 @@
 
 <div class="navbar navbar-fixed-top">
   <div class="container">
-    <a class="navbar-brand" href="https://github.com/the-simian/es6-plato">ES6 Plato on Github</a>
+    <a class="navbar-brand" href="https://github.com/the-simian/es6-plato">ES6 Plato on GitHub</a>
     <ul class="nav navbar-nav">
       <li>
         <a href="../../index.html">Report Home</a>

--- a/lib/templates/overview.html
+++ b/lib/templates/overview.html
@@ -27,7 +27,7 @@
 
 <div class="navbar navbar-fixed-top">
   <div class="container">
-    <a class="navbar-brand" href="https://github.com/the-simian/es6-plato">ES6 Plato on Github</a>
+    <a class="navbar-brand" href="https://github.com/the-simian/es6-plato">ES6 Plato on GitHub</a>
     <ul class="nav navbar-nav">
       <li class="active">
         <a href="index.html">Report Home</a>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`